### PR TITLE
Enhance price command with market data and refactor API utils

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -7,6 +7,11 @@ const commandHandlers = {
   [price.command.name]: price.handlePriceCommand,
 } as const;
 
+/**
+ * Registers global Discord slash commands and sets up interaction handlers for the client.
+ *
+ * Throws an error if the client application is not ready. Registers commands globally using the Discord REST API and logs the registration status. Listens for chat input command interactions and dispatches them to the appropriate handler, replying with an error message if the command is unknown or if an exception occurs during handling.
+ */
 export async function setupCommands(client: Client) {
   if (!client.application) {
     throw new Error("Client application is not ready");

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -19,9 +19,9 @@ export async function setupCommands(client: Client) {
   ].map((command) => command.toJSON());
   const rest = new REST({ version: "10" }).setToken(process.env.DISCORD_TOKEN!);
   try {
-    // Global commands (can take up to 1 hour) with our a guild ID 
-    await rest.put(Routes.applicationGuildCommands(client.application.id, config.DEFAULT_GUILD_ID), {
-    // await rest.put(Routes.applicationCommands(client.application.id), {
+    // Global commands (can take up to 1 hour) without a guild ID 
+    // await rest.put(Routes.applicationGuildCommands(client.application.id, config.DEFAULT_GUILD_ID), {
+    await rest.put(Routes.applicationCommands(client.application.id), {
       body: commands,
     });
     console.log("Successfully reloaded application (/) commands:");

--- a/src/commands/price.ts
+++ b/src/commands/price.ts
@@ -17,6 +17,11 @@ export const command = new SlashCommandBuilder()
   .setName("price")
   .setDescription("Get the current prices and liquidity for LABS and SOL.");
 
+/**
+ * Handles the `/price` Discord slash command by fetching and displaying current price, liquidity, market cap, holder count, and recent price changes for LABS and SOL tokens.
+ *
+ * Responds with an embedded message containing up-to-date token metrics, or an error message if data retrieval fails.
+ */
 export async function handlePriceCommand(
   interaction: ChatInputCommandInteraction
 ) {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,13 +1,150 @@
+import { CONSTANTS } from "./constants";
+
 export async function fetchTokenPrice(token: string): Promise<number> {
-      const [jupData] = await Promise.all([
-      fetch(
-        `https://lite-api.jup.ag/price/v2?ids=${token}`
-      ).then((res) => res.json()),
-    ]);
+  const [jupData] = await Promise.all([
+    fetch(`https://lite-api.jup.ag/price/v2?ids=${token}`).then((res) =>
+      res.json()
+    ),
+  ]);
 
-    const price = parseFloat(
-      jupData.data[token]?.price ?? "0"
+  const price = parseFloat(jupData.data[token]?.price ?? "0");
+
+  return price;
+}
+
+export async function fetchLiquidity(address: string): Promise<number | null> {
+  const token = process.env.BIRDEYE_TOKEN;
+
+  if (!token) {
+    console.warn("BirdEye API token is missing.");
+    return null;
+  }
+  try {
+    const res = await fetch(
+      `https://public-api.birdeye.so/defi/price?include_liquidity=true&address=${address}`,
+      {
+        method: "GET",
+        headers: {
+          accept: "application/json",
+          "x-chain": "solana",
+          "X-API-KEY": token,
+        },
+      }
     );
+    if (!res.ok) {
+      console.warn(`BirdEye API error for ${address}: ${res.statusText}`);
+      return null;
+    }
+    const data = await res.json();
+    return data?.success ? data.data.liquidity ?? null : null;
+  } catch (err) {
+    console.error(`Failed to fetch liquidity for ${address}:`, err);
+    return null;
+  }
+}
 
-    return price 
+export async function fetchTokenOverview(address: string): Promise<{
+  marketCap: number;
+  priceChange24hPercent: number;
+  holder: number;
+  liquidity: number;
+  raw: any;
+} | null> {
+  const token = process.env.BIRDEYE_TOKEN;
+  if (!token) {
+    console.warn("BirdEye API token is missing.");
+    return null;
+  }
+  try {
+    const res = await fetch(
+      `https://public-api.birdeye.so/defi/token_overview?address=${address}&frames=24h`,
+      {
+        method: "GET",
+        headers: {
+          accept: "application/json",
+          "x-chain": "solana",
+          "X-API-KEY": token,
+        },
+      }
+    );
+    if (!res.ok) {
+      console.warn(`BirdEye API error (token_overview): ${res.statusText}`);
+      return null;
+    }
+    const data = await res.json();
+    if (!data?.success || !data.data) return null;
+    return {
+      marketCap: data.data.marketCap,
+      priceChange24hPercent: data.data.priceChange24hPercent,
+      holder: data.data.holder,
+      liquidity: data.data.liquidity,
+      raw: data.data,
+    };
+  } catch (err) {
+    console.error("Failed to fetch LABS token overview:", err);
+    return null;
+  }
+}
+
+export async function fetchLabsHistoricalChange(currentPrice: number): Promise<{
+  change1w: number | null;
+  change1m: number | null;
+}> {
+  const token = process.env.BIRDEYE_TOKEN;
+  if (!token) {
+    console.warn("BirdEye API token is missing.");
+    return { change1w: null, change1m: null };
+  }
+
+  const address = CONSTANTS.TOKEN.LABS;
+  const now = Math.floor(Date.now() / 1000);
+  const oneWeekAgo = now - 7 * 24 * 60 * 60;
+  const oneMonthAgo = now - 30 * 24 * 60 * 60;
+  const time_to = 10000000000; // max value
+
+  const url = `https://public-api.birdeye.so/defi/history_price?address=${address}&address_type=token&type=1D&time_from=${oneMonthAgo}&time_to=${time_to}`;
+
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      headers: {
+        accept: "application/json",
+        "x-chain": "solana",
+        "X-API-KEY": token,
+      },
+    });
+    if (!res.ok) {
+      console.warn(`BirdEye API error (history_price): ${res.statusText}`);
+      return { change1w: null, change1m: null };
+    }
+    const data = await res.json();
+    if (!data?.success || !data.data?.items?.length) return { change1w: null, change1m: null };
+
+    // Find the closest price to 1w and 1m ago
+    let price1w: number | null = null;
+    let price1m: number | null = null;
+    let minDiff1w = Infinity;
+    let minDiff1m = Infinity;
+
+    for (const item of data.data.items) {
+      const diff1w = Math.abs(item.unixTime - oneWeekAgo);
+      if (diff1w < minDiff1w) {
+        minDiff1w = diff1w;
+        price1w = item.value;
+      }
+      const diff1m = Math.abs(item.unixTime - oneMonthAgo);
+      if (diff1m < minDiff1m) {
+        minDiff1m = diff1m;
+        price1m = item.value;
+      }
+    }
+
+    const change1w = price1w ? ((currentPrice - price1w) / price1w) * 100 : null;
+    const change1m = price1m ? ((currentPrice - price1m) / price1m) * 100 : null;
+
+    return { change1w, change1m };
+  } catch (err) {
+    console.error("Failed to fetch LABS historical price:", err);
+    return { change1w: null, change1m: null };
+  }
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,5 +1,11 @@
 import { CONSTANTS } from "./constants";
 
+/**
+ * Retrieves the current price of a specified token from the Jupiter API.
+ *
+ * @param token - The token identifier to fetch the price for
+ * @returns The current price of the token, or 0 if unavailable
+ */
 export async function fetchTokenPrice(token: string): Promise<number> {
   const jupData = await fetch(
     `https://lite-api.jup.ag/price/v2?ids=${token}`
@@ -10,6 +16,11 @@ export async function fetchTokenPrice(token: string): Promise<number> {
   return price;
 }
 
+/**
+ * Retrieves the liquidity value for a specified token address from the BirdEye API.
+ *
+ * Returns the liquidity as a number if available, or null if the API token is missing, the request fails, or liquidity data is unavailable.
+ */
 export async function fetchLiquidity(address: string): Promise<number | null> {
   const token = process.env.BIRDEYE_TOKEN;
 
@@ -41,6 +52,12 @@ export async function fetchLiquidity(address: string): Promise<number | null> {
   }
 }
 
+/**
+ * Retrieves a token overview from the BirdEye API, including market capitalization, 24-hour price change percentage, holder count, liquidity, and raw data.
+ *
+ * @param address - The token address to fetch the overview for
+ * @returns An object containing marketCap, priceChange24hPercent, holder, liquidity, and raw data, or null if unavailable
+ */
 export async function fetchTokenOverview(address: string): Promise<{
   marketCap: number;
   priceChange24hPercent: number;
@@ -84,6 +101,12 @@ export async function fetchTokenOverview(address: string): Promise<{
   }
 }
 
+/**
+ * Calculates the 1-week and 1-month percentage price changes for the LABS token based on historical price data from the BirdEye API.
+ *
+ * @param currentPrice - The current price of the LABS token used as the reference for change calculations.
+ * @returns An object containing the percentage changes over 1 week (`change1w`) and 1 month (`change1m`), or `null` values if data is unavailable.
+ */
 export async function fetchLabsHistoricalChange(currentPrice: number): Promise<{
   change1w: number | null;
   change1m: number | null;

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -100,9 +100,9 @@ export async function fetchLabsHistoricalChange(currentPrice: number): Promise<{
   const now = Math.floor(Date.now() / 1000);
   const oneWeekAgo = now - 7 * 24 * 60 * 60;
   const oneMonthAgo = now - 30 * 24 * 60 * 60;
-  const time_to = 10000000000; // max value
+  const MAX_TIMESTAMP = 10000000000; // Maximum Unix timestamp for API queries
 
-  const url = `https://public-api.birdeye.so/defi/history_price?address=${address}&address_type=token&type=1D&time_from=${oneMonthAgo}&time_to=${time_to}`;
+  const url = `https://public-api.birdeye.so/defi/history_price?address=${address}&address_type=token&type=1D&time_from=${oneMonthAgo}&time_to=${MAX_TIMESTAMP}`;
 
   try {
     const res = await fetch(url, {
@@ -118,7 +118,8 @@ export async function fetchLabsHistoricalChange(currentPrice: number): Promise<{
       return { change1w: null, change1m: null };
     }
     const data = await res.json();
-    if (!data?.success || !data.data?.items?.length) return { change1w: null, change1m: null };
+    if (!data?.success || !data.data?.items?.length)
+      return { change1w: null, change1m: null };
 
     // Find the closest price to 1w and 1m ago
     let price1w: number | null = null;
@@ -139,8 +140,12 @@ export async function fetchLabsHistoricalChange(currentPrice: number): Promise<{
       }
     }
 
-    const change1w = price1w ? ((currentPrice - price1w) / price1w) * 100 : null;
-    const change1m = price1m ? ((currentPrice - price1m) / price1m) * 100 : null;
+    const change1w = price1w
+      ? ((currentPrice - price1w) / price1w) * 100
+      : null;
+    const change1m = price1m
+      ? ((currentPrice - price1m) / price1m) * 100
+      : null;
 
     return { change1w, change1m };
   } catch (err) {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,11 +1,9 @@
 import { CONSTANTS } from "./constants";
 
 export async function fetchTokenPrice(token: string): Promise<number> {
-  const [jupData] = await Promise.all([
-    fetch(`https://lite-api.jup.ag/price/v2?ids=${token}`).then((res) =>
-      res.json()
-    ),
-  ]);
+  const jupData = await fetch(
+    `https://lite-api.jup.ag/price/v2?ids=${token}`
+  ).then((res) => res.json());
 
   const price = parseFloat(jupData.data[token]?.price ?? "0");
 
@@ -48,7 +46,7 @@ export async function fetchTokenOverview(address: string): Promise<{
   priceChange24hPercent: number;
   holder: number;
   liquidity: number;
-  raw: any;
+  raw: Record<string, unknown>;
 } | null> {
   const token = process.env.BIRDEYE_TOKEN;
   if (!token) {


### PR DESCRIPTION
Resolve #1 

Refactored liquidity fetching logic into api.ts and expanded the price command to display additional LABS token metrics, including market cap, holders, and historical price changes (1d, 1w, 1m). Added new utility functions to fetch token overview and historical price changes from BirdEye API, improving the richness of the price command's output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded the price command to display additional token metrics, including market capitalization, holder count, and price changes over 24 hours, 1 week, and 1 month.
  - Enhanced data sources for price and liquidity information, now referencing both BirdEye and Jupiter APIs.

- **Chores**
  - Updated command registration to use global commands instead of guild-specific commands, affecting how quickly new commands become available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->