### PR TITLE
feat: add volume info 

### DIFF
--- a/src/commands/price.ts
+++ b/src/commands/price.ts
@@ -34,14 +34,10 @@ export async function handlePriceCommand(
     const solPrice = await fetchTokenPrice(CONSTANTS.TOKEN.SOL);
     const labsOverview = await fetchTokenOverview(CONSTANTS.TOKEN.LABS);
     const { change1w, change1m } = await fetchLabsHistoricalChange(labsPrice);
-    const labsVolumeData = await fetchTokenPriceVolume(
-      CONSTANTS.TOKEN.LABS,
-      "24h"
-    );
-    const labsVolumeData1Hr = await fetchTokenPriceVolume(
-      CONSTANTS.TOKEN.LABS,
-      "1h"
-    );
+    const [labsVolumeData, labsVolumeData1Hr] = await Promise.all([
+      fetchTokenPriceVolume(CONSTANTS.TOKEN.LABS, "24h"),
+      fetchTokenPriceVolume(CONSTANTS.TOKEN.LABS, "1h"),
+    ]);
 
     if (labsPrice && solPrice) {
       const formattedLabs = `$${labsPrice.toFixed(4)}`;

--- a/src/commands/price.ts
+++ b/src/commands/price.ts
@@ -34,8 +34,14 @@ export async function handlePriceCommand(
     const solPrice = await fetchTokenPrice(CONSTANTS.TOKEN.SOL);
     const labsOverview = await fetchTokenOverview(CONSTANTS.TOKEN.LABS);
     const { change1w, change1m } = await fetchLabsHistoricalChange(labsPrice);
-    const labsVolumeData = await fetchTokenPriceVolume(CONSTANTS.TOKEN.LABS, "24h");
-    const labsVolumeData1Hr = await fetchTokenPriceVolume(CONSTANTS.TOKEN.LABS, "1h");
+    const labsVolumeData = await fetchTokenPriceVolume(
+      CONSTANTS.TOKEN.LABS,
+      "24h"
+    );
+    const labsVolumeData1Hr = await fetchTokenPriceVolume(
+      CONSTANTS.TOKEN.LABS,
+      "1h"
+    );
 
     if (labsPrice && solPrice) {
       const formattedLabs = `$${labsPrice.toFixed(4)}`;
@@ -110,13 +116,13 @@ export async function handlePriceCommand(
             inline: true,
           },
           {
-            name: "1D Volume",
-            value: formatters.codeBlock(formattedVolumeDUSD),
+            name: "1Hr Volume",
+            value: formatters.codeBlock(formattedVolumeHrUsd),
             inline: true,
           },
           {
-            name: "1Hr Volume",
-            value: formatters.codeBlock(formattedVolumeHrUsd),
+            name: "1D Volume",
+            value: formatters.codeBlock(formattedVolumeDUSD),
             inline: true,
           },
           { name: "\u200B", value: "\u200B", inline: true }, // filler for layout

--- a/src/commands/price.ts
+++ b/src/commands/price.ts
@@ -10,6 +10,7 @@ import {
   fetchTokenPrice,
   fetchTokenOverview,
   fetchLabsHistoricalChange,
+  fetchTokenPriceVolume,
 } from "../utils/api";
 import { config } from "../config";
 
@@ -33,12 +34,20 @@ export async function handlePriceCommand(
     const solPrice = await fetchTokenPrice(CONSTANTS.TOKEN.SOL);
     const labsOverview = await fetchTokenOverview(CONSTANTS.TOKEN.LABS);
     const { change1w, change1m } = await fetchLabsHistoricalChange(labsPrice);
+    const labsVolumeData = await fetchTokenPriceVolume(CONSTANTS.TOKEN.LABS, "24h");
+    const labsVolumeData1Hr = await fetchTokenPriceVolume(CONSTANTS.TOKEN.LABS, "1h");
 
     if (labsPrice && solPrice) {
       const formattedLabs = `$${labsPrice.toFixed(4)}`;
       const formattedSOL = `$${solPrice.toFixed(config.PRICE_DECIMAL_PLACES)}`;
       const labsPerSol = labsPrice / solPrice;
       const formattedLabsSol = labsPerSol.toFixed(6);
+      const formattedVolumeDUSD = labsVolumeData
+        ? `$${formatters.usdValue(labsVolumeData.volumeUSD)}`
+        : "N/A";
+      const formattedVolumeHrUsd = labsVolumeData1Hr
+        ? `$${formatters.usdValue(labsVolumeData1Hr.volumeUSD)}`
+        : "N/A";
 
       const formattedLabsLiquidity = labsOverview
         ? `$${formatters.usdValue(labsOverview.liquidity)}`
@@ -100,6 +109,17 @@ export async function handlePriceCommand(
             value: formatters.codeBlock(formattedChange1m),
             inline: true,
           },
+          {
+            name: "1D Volume",
+            value: formatters.codeBlock(formattedVolumeDUSD),
+            inline: true,
+          },
+          {
+            name: "1Hr Volume",
+            value: formatters.codeBlock(formattedVolumeHrUsd),
+            inline: true,
+          },
+          { name: "\u200B", value: "\u200B", inline: true }, // filler for layout
           { name: "**📈 Market Tokens**", value: "", inline: false },
           {
             name: "SOL",

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -174,3 +174,44 @@ export async function fetchLabsHistoricalChange(currentPrice: number): Promise<{
     return { change1w: null, change1m: null };
   }
 }
+
+/**
+ * Fetches price/volume data for a token from BirdEye for a given interval.
+ * @param address The token address.
+ * @param interval The interval type, e.g., "24h", "1h".
+ */
+export async function fetchTokenPriceVolume(
+  address: string,
+  interval: "24h" | "1h" = "24h"
+): Promise<{
+  price: number;
+  priceChangePercent: number;
+  volumeUSD: number;
+  volumeChangePercent: number;
+} | null> {
+  try {
+    const res = await fetch(
+      `https://public-api.birdeye.so/defi/price_volume/single?address=${address}&type=${interval}`,
+      {
+        method: "GET",
+        headers: {
+          accept: "application/json",
+          "x-chain": "solana",
+          "X-API-KEY": process.env.BIRDEYE_TOKEN || "",
+        },
+      }
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    if (!data.success) return null;
+    return {
+      price: data.data.price,
+      priceChangePercent: data.data.priceChangePercent,
+      volumeUSD: data.data.volumeUSD,
+      volumeChangePercent: data.data.volumeChangePercent,
+    };
+  } catch (err) {
+    console.error("Failed to fetch price/volume:", err);
+    return null;
+  }
+}

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -189,6 +189,12 @@ export async function fetchTokenPriceVolume(
   volumeUSD: number;
   volumeChangePercent: number;
 } | null> {
+  const token = process.env.BIRDEYE_TOKEN;
+  if (!token) {
+    console.warn("BirdEye API token is missing.");
+    return null;
+  }
+
   try {
     const res = await fetch(
       `https://public-api.birdeye.so/defi/price_volume/single?address=${address}&type=${interval}`,
@@ -197,11 +203,16 @@ export async function fetchTokenPriceVolume(
         headers: {
           accept: "application/json",
           "x-chain": "solana",
-          "X-API-KEY": process.env.BIRDEYE_TOKEN || "",
+          "X-API-KEY": token,
         },
       }
     );
-    if (!res.ok) return null;
+    if (!res.ok) {
+      console.warn(
+        `BirdEye API error (price_volume) for ${address}: ${res.statusText}`
+      );
+      return null;
+    }
     const data = await res.json();
     if (!data.success) return null;
     return {
@@ -211,7 +222,7 @@ export async function fetchTokenPriceVolume(
       volumeChangePercent: data.data.volumeChangePercent,
     };
   } catch (err) {
-    console.error("Failed to fetch price/volume:", err);
+    console.error(`Failed to fetch price/volume for ${address}:`, err);
     return null;
   }
 }


### PR DESCRIPTION
Added Volume information for https://github.com/EpicentralLabs/discord-price-bot/issues/4

<img width="415" height="460" alt="image" src="https://github.com/user-attachments/assets/47188c81-faec-4550-a11e-4811b29fbc7d" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added display of LABS token trading volume for 24 hours and 1 hour in the `/price` command output on Discord.
  * Volume metrics are shown as formatted USD values or "N/A" if unavailable, enhancing the information provided to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->